### PR TITLE
Refine Vercel APIs

### DIFF
--- a/api/assist.js
+++ b/api/assist.js
@@ -1,85 +1,106 @@
 // api/assist.js
+const path = require('path');
 
-// i tryRequireCore: prøv '../core' og '/var/task/core'
-
-// --- CORS whitelist (legg evt. til flere domener ved behov) ---
-const ALLOWED_ORIGINS = [
+const BASE_ALLOWED_ORIGINS = [
+  'https://lunamedia.vercel.app',
+  'https://lunamedia-git-main-lunamedia.vercel.app',
   'https://h05693dfe8-staging.onrocket.site',
+  'https://lunamedia.no',
 ];
 
+function buildAllowedOrigins() {
+  const extra = (process.env.LUNA_ALLOWED_ORIGINS || '')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+  return Array.from(new Set([...BASE_ALLOWED_ORIGINS, ...extra]));
+}
+
 function applyCors(req, res) {
+  const allowedOrigins = buildAllowedOrigins();
   const origin = req.headers.origin || '';
-  if (ALLOWED_ORIGINS.includes(origin)) {
+  if (allowedOrigins.includes(origin)) {
     res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Vary', 'Origin');
   }
   res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
 }
 
-// --- Hjelpefunksjon: parse body ---
 function parseBody(req) {
-  let body = req.body;
+  const body = req.body;
+  if (!body) return {};
+  if (typeof body === 'object') return body;
   if (typeof body === 'string') {
-    try { body = JSON.parse(body); } catch {}
+    try {
+      return JSON.parse(body);
+    } catch (_) {
+      return {};
+    }
   }
-  return body || {};
+  return {};
 }
 
-// --- Hjelpefunksjon: prøv å require core ---
-function tryRequireCore() {
-  const tries = [
-    '../core',             // api/* -> ../core
-    '/var/task/api/core',  // absolutt Vercel-sti
-    '/var/task/core',      // fallback
+function resolveCoreModule() {
+  const guesses = [
+    path.join(__dirname, '..', 'core'),
+    path.join(process.cwd(), 'core'),
+    '/var/task/core',
   ];
-  for (const p of tries) {
-    try { return require(p); } catch {}
+
+  for (const candidate of guesses) {
+    try {
+      const mod = require(candidate);
+      if (mod && typeof mod.createAssistant === 'function') {
+        return mod;
+      }
+    } catch (_) {}
   }
   return null;
 }
 
-// --- Bestem om vi skal bruke modulær assistent ---
-function computeUseModular() {
-  const mode = (process.env.ASSISTANT_MODE || '').toLowerCase();
-  const flag = (process.env.USE_MODULAR_ASSISTANT || '').toLowerCase();
-  if (mode === 'modular' || flag === '1' || flag === 'true') return true;
-  return !!tryRequireCore(); // fallback: aktiver hvis core faktisk finnes
+function extractText(req) {
+  const method = (req.method || 'GET').toUpperCase();
+  if (method === 'GET') {
+    const query = req.query || {};
+    return query.text || query.message || '';
+  }
+  const body = parseBody(req);
+  return body.text || body.message || '';
 }
 
-// --- Selve handleren ---
 module.exports = async (req, res) => {
   applyCors(req, res);
-  if (req.method === 'OPTIONS') return res.status(204).end();
-
-  const useModular = computeUseModular();
+  if ((req.method || '').toUpperCase() === 'OPTIONS') {
+    res.status(204).end();
+    return;
+  }
 
   try {
-    const method = (req.method || 'GET').toUpperCase();
-    const fromQuery = (req.query && (req.query.text || req.query.message)) || '';
-    const body = parseBody(req);
-    const fromBody = body.text || body.message || '';
-    const text = method === 'GET' ? fromQuery : fromBody;
-
-    if (useModular) {
-      const core = tryRequireCore();
-      if (core && typeof core.createAssistant === 'function') {
-        const assistant = core.createAssistant();
-        const reply = await assistant.handle({ text: String(text || '') });
-        return res.status(200).json(reply);
-      }
+    const core = resolveCoreModule();
+    if (!core) {
+      res.status(500).json({
+        error: 'Modul core ikke tilgjengelig',
+      });
+      return;
     }
 
-    // --- Fallback (legacy) ---
-    return res.status(200).json({
-      type: 'answer',
-      text: 'Legacy assist svar (fallback).'
-    });
+    const assistant = core.createAssistant();
+    if (!assistant || typeof assistant.handle !== 'function') {
+      res.status(500).json({
+        error: 'createAssistant() returnerte ingen gyldig assistent',
+      });
+      return;
+    }
+
+    const text = String(extractText(req) || '');
+    const reply = await assistant.handle({ text });
+    res.status(200).json(reply || {});
   } catch (err) {
-    console.error('API /api/assist feilet:', err);
-    return res.status(500).json({
-      error: 'Internal error',
-      details: String(err?.message || err)
+    console.error('[api/assist] Feil:', err);
+    res.status(500).json({
+      error: 'Internal Server Error',
+      details: String(err && err.message ? err.message : err),
     });
   }
 };

--- a/api/debug.js
+++ b/api/debug.js
@@ -2,137 +2,198 @@
 const fs = require('fs');
 const path = require('path');
 
-// ---- CORS (legg til flere domener ved behov) ----
-const ALLOWED_ORIGINS = ['https://h05693dfe8-staging.onrocket.site'];
-function cors(req, res) {
-  const o = req.headers.origin || '';
-  if (ALLOWED_ORIGINS.includes(o)) {
-    res.setHeader('Access-Control-Allow-Origin', o);
+const BASE_ALLOWED_ORIGINS = [
+  'https://lunamedia.vercel.app',
+  'https://lunamedia-git-main-lunamedia.vercel.app',
+  'https://h05693dfe8-staging.onrocket.site',
+  'https://lunamedia.no',
+];
+
+function buildAllowedOrigins() {
+  const extra = (process.env.LUNA_ALLOWED_ORIGINS || '')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+  return Array.from(new Set([...BASE_ALLOWED_ORIGINS, ...extra]));
+}
+
+function applyCors(req, res) {
+  const allowedOrigins = buildAllowedOrigins();
+  const origin = req.headers.origin || '';
+  if (allowedOrigins.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Vary', 'Origin');
   }
   res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
 }
-function ok204(req, res){ if (req.method === 'OPTIONS') { res.status(204).end(); return true; } return false; }
 
-// ---- helpers for requires ----
-function tryRequireCore() {
-  const tries = ['../core','/var/task/core'];
-  for (const p of tries) { try { return require(p); } catch {} }
-  return null;
+function handleOptions(req, res) {
+  if ((req.method || '').toUpperCase() === 'OPTIONS') {
+    res.status(204).end();
+    return true;
+  }
+  return false;
 }
-function tryLoadKnowledgeFn() {
-  const tries = ['../data/loadData','/var/task/data/loadData'];
-  for (const p of tries) {
+
+function resolveCoreModule() {
+  const guesses = [
+    path.join(__dirname, '..', 'core'),
+    path.join(process.cwd(), 'core'),
+    '/var/task/core',
+  ];
+  for (const candidate of guesses) {
     try {
-      const m = require(p);
-      if (m && typeof m.loadKnowledge === 'function') return m.loadKnowledge;
-    } catch {}
+      const mod = require(candidate);
+      if (mod && typeof mod.createAssistant === 'function') {
+        return mod;
+      }
+    } catch (_) {}
   }
   return null;
 }
 
-// ---- sub-ops ----
-async function op_env() {
+function resolveLoadKnowledge() {
+  const guesses = [
+    path.join(__dirname, '..', 'data', 'loadData.js'),
+    path.join(process.cwd(), 'data', 'loadData.js'),
+    '/var/task/data/loadData.js',
+  ];
+  for (const candidate of guesses) {
+    try {
+      const mod = require(candidate);
+      if (mod && typeof mod.loadKnowledge === 'function') {
+        return mod.loadKnowledge;
+      }
+    } catch (_) {}
+  }
+  return null;
+}
+
+async function opEnv() {
   return {
+    node: process.version,
     ASSISTANT_MODE: process.env.ASSISTANT_MODE || 'unset',
     USE_MODULAR_ASSISTANT: process.env.USE_MODULAR_ASSISTANT || 'unset',
     DEBUG_ASSISTANT: process.env.DEBUG_ASSISTANT || 'unset',
-    node: process.version,
+    VERCEL_ENV: process.env.VERCEL_ENV || 'unset',
   };
 }
-async function op_mode() {
-  const flag = (process.env.USE_MODULAR_ASSISTANT||'').toLowerCase();
-  const mode = (process.env.ASSISTANT_MODE||'').toLowerCase();
-  const computed = (mode==='modular' || flag==='1' || flag==='true');
-  return { computed: { useModular: computed }, env: { ASSISTANT_MODE: mode || 'unset', USE_MODULAR_ASSISTANT: flag || 'unset' } };
-}
-async function op_ping(){ return { ok:true, now: Date.now() }; }
 
-async function op_ls(q) {
-  const roots = ['/var/task','/var/task/core','/var/task/data','/var/task/knowledge','/var/task/api'];
-  const pattern = String(q.pattern || '').toLowerCase() || null;
-  async function walk(root, out=[], depth=0, maxDepth=6){
-    try{
-      const ents = await fs.promises.readdir(root, { withFileTypes:true });
-      for(const e of ents){
-        const p = path.join(root, e.name);
-        const rel = p.replace('/var/task','');
-        if(!pattern || rel.toLowerCase().includes(pattern)) out.push(rel || '/');
-        if(e.isDirectory() && depth<maxDepth) await walk(p, out, depth+1, maxDepth);
-      }
-    }catch(_){}
-    return out;
-  }
-  const results = {};
-  for(const r of roots) results[r] = await walk(r);
-  return { ok:true, node: process.version, roots, pattern, results };
-}
-
-async function op_which(){
-  const core = tryRequireCore();
-  const hasCreate = !!(core && typeof core.createAssistant === 'function');
+async function opMode() {
+  const mode = (process.env.ASSISTANT_MODE || '').toLowerCase();
+  const flag = (process.env.USE_MODULAR_ASSISTANT || '').toLowerCase();
+  const useModular = mode === 'modular' || flag === '1' || flag === 'true';
   return {
-    ok: true,
-    required: hasCreate ? ['createAssistant'] : [],
-    hasCreate,
-    error: hasCreate ? null : 'Fant ikke core eller createAssistant'
+    computed: { useModular },
+    env: { ASSISTANT_MODE: mode || 'unset', USE_MODULAR_ASSISTANT: flag || 'unset' },
   };
 }
 
-async function op_knowledge(){
-  const loadKnowledge = tryLoadKnowledgeFn();
-  if(!loadKnowledge) return { ok:false, error:'Fant ikke loadData i noen kjente stier' };
-  try{
+async function opWhich() {
+  const core = resolveCoreModule();
+  return {
+    ok: !!core,
+    hasCreateAssistant: !!(core && typeof core.createAssistant === 'function'),
+  };
+}
+
+async function opKnowledge() {
+  const loadKnowledge = resolveLoadKnowledge();
+  if (!loadKnowledge) {
+    return { ok: false, error: 'Fant ikke loadKnowledge() i data/loadData.js' };
+  }
+  try {
     const data = loadKnowledge();
-    const files = data?.files || [];
-    const faqCount = data?.count?.faq ?? data?.faq?.length ?? 0;
-    const sample = (data?.faq || []).slice(0,5).map(x => ({ id:x.id, q:x.q, src: x.source || x._src }));
-    return { ok:true, files: files.length, faqCount, sample };
-  }catch(e){
-    return { ok:false, error: String(e?.message || e) };
+    const faq = Array.isArray(data?.faq) ? data.faq : [];
+    const sample = faq.slice(0, 5).map((item) => ({
+      id: item.id,
+      q: item.q,
+      source: item._src,
+    }));
+    return {
+      ok: true,
+      files: Array.isArray(data?.faqIndex?.files) ? data.faqIndex.files.length : 0,
+      faqCount: faq.length,
+      sample,
+    };
+  } catch (err) {
+    return { ok: false, error: String(err && err.message ? err.message : err) };
   }
 }
 
-async function op_company(){
-  const loadKnowledge = tryLoadKnowledgeFn();
-  if(!loadKnowledge) return { ok:false, error:'Finner ikke loadKnowledge()' };
-  try{
+async function opCompany() {
+  const loadKnowledge = resolveLoadKnowledge();
+  if (!loadKnowledge) {
+    return { ok: false, error: 'Fant ikke loadKnowledge()' };
+  }
+  try {
     const data = loadKnowledge();
     return {
       ok: true,
-      hasCompany: !!data?.meta?.company,
+      hasCompany: !!(data && data.meta && data.meta.company),
       company: data?.meta?.company || null,
       services: data?.meta?.services || [],
       prices: data?.meta?.prices || {},
       delivery: data?.meta?.delivery || {},
-      sources: (data?.files || []).length
+      sources: Array.isArray(data?.faqIndex?.files) ? data.faqIndex.files.length : 0,
     };
-  }catch(e){
-    return { ok:false, error: String(e?.message || e) };
+  } catch (err) {
+    return { ok: false, error: String(err && err.message ? err.message : err) };
   }
 }
 
-// ---- main multiplexer ----
-module.exports = async (req, res) => {
-  cors(req, res);
-  if (ok204(req, res)) return;
+async function opLs(query) {
+  const roots = ['/var/task', '/var/task/core', '/var/task/data', '/var/task/knowledge', '/var/task/api'];
+  const pattern = String((query && query.pattern) || '').toLowerCase() || null;
 
-  try{
-    const fn = (req.query && req.query.fn) || 'env';
-    let out;
-    switch(fn){
-      case 'env': out = await op_env(); break;
-      case 'mode': out = await op_mode(); break;
-      case 'ping': out = await op_ping(); break;
-      case 'ls': out = await op_ls(req.query||{}); break;
-      case 'which': out = await op_which(); break;
-      case 'knowledge': out = await op_knowledge(); break;
-      case 'company': out = await op_company(); break;
-      default: out = { ok:false, error:`Ukjent fn=${fn}` };
+  async function walk(root, out = [], depth = 0, maxDepth = 5) {
+    try {
+      const entries = await fs.promises.readdir(root, { withFileTypes: true });
+      for (const entry of entries) {
+        const full = path.join(root, entry.name);
+        const rel = full.replace('/var/task', '') || '/';
+        if (!pattern || rel.toLowerCase().includes(pattern)) {
+          out.push(rel);
+        }
+        if (entry.isDirectory() && depth < maxDepth) {
+          await walk(full, out, depth + 1, maxDepth);
+        }
+      }
+    } catch (_) {}
+    return out;
+  }
+
+  const results = {};
+  for (const root of roots) {
+    results[root] = await walk(root);
+  }
+  return { ok: true, pattern, results };
+}
+
+const OPS = {
+  env: opEnv,
+  mode: opMode,
+  which: opWhich,
+  knowledge: opKnowledge,
+  company: opCompany,
+  ls: opLs,
+};
+
+module.exports = async (req, res) => {
+  applyCors(req, res);
+  if (handleOptions(req, res)) return;
+
+  try {
+    const fn = String((req.query && req.query.fn) || 'env');
+    const handler = OPS[fn];
+    if (!handler) {
+      res.status(400).json({ ok: false, error: `Ukjent fn=${fn}` });
+      return;
     }
-    res.status(200).json(out);
-  }catch(err){
-    res.status(500).json({ ok:false, error: String(err?.message || err) });
+    const result = await handler(req.query || {});
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ ok: false, error: String(err && err.message ? err.message : err) });
   }
 };

--- a/api/ping.js
+++ b/api/ping.js
@@ -1,4 +1,0 @@
-// api/ping.js
-module.exports = async (req, res) => {
-  res.status(200).json({ ok: true, now: Date.now() });
-};

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,13 @@
 {
   "version": 2,
-  "builds": [
-    { "src": "api/**/*.js", "use": "@vercel/node@3.0.24" }
-  ],
   "functions": {
     "api/*.js": {
       "runtime": "nodejs20.x",
-      "includeFiles": "{core,data,knowledge}/**"
+      "includeFiles": [
+        "core/**",
+        "data/**",
+        "knowledge/**"
+      ]
     }
   },
   "routes": [


### PR DESCRIPTION
## Summary
- consolidate the serverless surface to /api/assist and /api/debug with a shared CORS whitelist and assistant wiring
- harden core assistant loading so knowledge data is discovered reliably at runtime
- configure the Vercel functions bundle for Node.js 20 with core, data, and knowledge assets included

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0d8f61b688332ae44c58b961fdf00